### PR TITLE
Fix people images and homepage alignment

### DIFF
--- a/acrylic_painting.html
+++ b/acrylic_painting.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>About | Kokomo Art Association</title>
+  <title>Acrylic Painting | Kokomo Art Association</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -12,10 +12,10 @@
       <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="about.html" class="active">About</a></li>
+        <li><a href="about.html">About</a></li>
         <li><a href="people.html">People</a></li>
         <li><a href="events.html">Events</a></li>
-        <li><a href="classes.html">Classes</a></li>
+        <li><a href="classes.html" class="active">Classes</a></li>
         <li><a href="artworks_gallery.html">Gallery</a></li>
         <li><a href="membership.html">Join</a></li>
         <li><a href="volunteer.html">Volunteer</a></li>
@@ -24,30 +24,10 @@
       </ul>
     </nav>
   </header>
-
   <main id="content" class="container">
-    <h1>About the Kokomo Art Association</h1>
-    <p class="lead">Since 1926, the Kokomo Art Association (KAA) has championed visual arts education, exhibition, and community engagement throughout north‑central Indiana.</p>
-
-    <h2>Our Mission</h2>
-    <p>To connect, educate, and inspire through the visual arts, ensuring art is accessible to <em>all</em> in our community.</p>
-
-    <h2>Centennial Timeline</h2>
-    <ul class="timeline">
-      <li><strong>1926:</strong> First informal gathering of local artists; KAA founded.</li>
-      <li><strong>1950s–1970s:</strong> Regular juried shows, school outreach, and traveling exhibits.</li>
-      <li><strong>2014:</strong> Artist Alley opens in downtown Kokomo.</li>
-      <li><strong>2025:</strong> 12th Annual Artist Alley project and centennial celebrations underway.</li>
-    </ul>
-
-    <h2>Impact by the Numbers (2024)</h2>
-    <ul>
-      <li>📈 4,200 gallery visitors</li>
-      <li>🎨 630 class enrollments</li>
-      <li>🖼️ 95 regional artists exhibited</li>
-    </ul>
+    <h1>Acrylic Painting</h1>
+    <p class="lead">More information about this class will be available soon.</p>
   </main>
-
   <footer>
     <div class="footer-links container">
       <a href="about.html">About</a>
@@ -58,7 +38,6 @@
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>
-
   <script src="app.js"></script>
 </body>
 </html>

--- a/artworks_gallery.html
+++ b/artworks_gallery.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery" class="active">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html" class="active">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -47,11 +47,11 @@
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/classes.html
+++ b/classes.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes" class="active">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html" class="active">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -34,30 +34,30 @@
         <h2>Watercolor Techniques</h2>
         <p>Instructor: Ramona Daniels</p>
         <p>Tuesdays Aug 5–26, 6 PM</p>
-        <a href="/watercolor-techniques" class="cta">Details</a>
+        <a href="watercolor_techniques.html" class="cta">Details</a>
       </article>
       <article class="class-card" data-date="2025-09-10">
         <h2>Acrylic Painting</h2>
         <p>Instructor: Steve Creighton</p>
         <p>Wednesdays Sep 10–Oct 1, 6 PM</p>
-        <a href="/acrylic-painting" class="cta">Details</a>
+        <a href="acrylic_painting.html" class="cta">Details</a>
       </article>
       <article class="class-card" data-date="2025-11-02">
         <h2>Digital Photography</h2>
         <p>Instructor: Lisa Freeland</p>
         <p>Saturdays Nov 2–23, 1 PM</p>
-        <a href="/digital-photography" class="cta">Details</a>
+        <a href="digital_photography.html" class="cta">Details</a>
       </article>
     </div>
   </main>
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/contact_us.html
+++ b/contact_us.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us" class="active">Contact</a></li>
+        <li><a href="contact_us.html" class="active">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -41,11 +41,11 @@
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/digital_photography.html
+++ b/digital_photography.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>About | Kokomo Art Association</title>
+  <title>Digital Photography | Kokomo Art Association</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -12,10 +12,10 @@
       <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="about.html" class="active">About</a></li>
+        <li><a href="about.html">About</a></li>
         <li><a href="people.html">People</a></li>
         <li><a href="events.html">Events</a></li>
-        <li><a href="classes.html">Classes</a></li>
+        <li><a href="classes.html" class="active">Classes</a></li>
         <li><a href="artworks_gallery.html">Gallery</a></li>
         <li><a href="membership.html">Join</a></li>
         <li><a href="volunteer.html">Volunteer</a></li>
@@ -24,30 +24,10 @@
       </ul>
     </nav>
   </header>
-
   <main id="content" class="container">
-    <h1>About the Kokomo Art Association</h1>
-    <p class="lead">Since 1926, the Kokomo Art Association (KAA) has championed visual arts education, exhibition, and community engagement throughout north‑central Indiana.</p>
-
-    <h2>Our Mission</h2>
-    <p>To connect, educate, and inspire through the visual arts, ensuring art is accessible to <em>all</em> in our community.</p>
-
-    <h2>Centennial Timeline</h2>
-    <ul class="timeline">
-      <li><strong>1926:</strong> First informal gathering of local artists; KAA founded.</li>
-      <li><strong>1950s–1970s:</strong> Regular juried shows, school outreach, and traveling exhibits.</li>
-      <li><strong>2014:</strong> Artist Alley opens in downtown Kokomo.</li>
-      <li><strong>2025:</strong> 12th Annual Artist Alley project and centennial celebrations underway.</li>
-    </ul>
-
-    <h2>Impact by the Numbers (2024)</h2>
-    <ul>
-      <li>📈 4,200 gallery visitors</li>
-      <li>🎨 630 class enrollments</li>
-      <li>🖼️ 95 regional artists exhibited</li>
-    </ul>
+    <h1>Digital Photography</h1>
+    <p class="lead">More information about this class will be available soon.</p>
   </main>
-
   <footer>
     <div class="footer-links container">
       <a href="about.html">About</a>
@@ -58,7 +38,6 @@
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>
-
   <script src="app.js"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events" class="active">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html" class="active">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -40,7 +40,7 @@
         <h2>Fall Member Exhibition Reception</h2>
         <p class="date">October 1 , 2025 – 5 PM</p>
         <p class="intro">Meet featured artists and enjoy live music at the Kokomo Art Center.</p>
-        <a href="/membership" class="cta">Members Join Free</a>
+        <a href="membership.html" class="cta">Members Join Free</a>
       </article>
 
       <article class="event" data-date="2025-06-14">
@@ -53,11 +53,11 @@
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/index.html
+++ b/index.html
@@ -6,21 +6,21 @@
   <title>Kokomo Art Association</title>
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body class="home">
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -30,8 +30,8 @@
       <h1>Art for All. Since 1926.</h1>
       <p class="lead">Connecting community through the visual arts in Kokomo, Indiana.</p>
       <div class="actions">
-        <a class="cta primary" href="/events">See Events</a>
-        <a class="cta" href="/membership">Become a Member</a>
+        <a class="cta primary" href="events.html">See Events</a>
+        <a class="cta" href="membership.html">Become a Member</a>
       </div>
     </section>
 
@@ -39,12 +39,12 @@
       <article class="highlight">
         <h2>Visit the Artworks Gallery</h2>
         <p>Explore rotating exhibitions from regional artists.</p>
-        <a href="/artworks-gallery" class="link-arrow">Plan Your Visit →</a>
+        <a href="artworks_gallery.html" class="link-arrow">Plan Your Visit →</a>
       </article>
       <article class="highlight">
         <h2>Take a Class</h2>
         <p>From watercolor to digital photography—learn new skills.</p>
-        <a href="/classes" class="link-arrow">Browse Classes →</a>
+        <a href="classes.html" class="link-arrow">Browse Classes →</a>
       </article>
       <article class="highlight">
         <h2>Support Our Mission</h2>
@@ -52,6 +52,22 @@
         <a href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener" class="link-arrow">Donate Now →</a>
       </article>
     </section>
+
+    <section class="pages container">
+      <h2>Explore KAA</h2>
+      <ul class="page-links">
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Membership</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
+        <li><a href="contact_us.html">Contact Us</a></li>
+        <li><a href="privacy.html">Privacy Policy</a></li>
+      </ul>
+    </section>
+
 
     <section class="social container">
       <h2>Follow Along</h2>
@@ -64,11 +80,11 @@
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/membership.html
+++ b/membership.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership" class="active">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html" class="active">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -56,11 +56,11 @@
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/people.html
+++ b/people.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people" class="active">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html" class="active">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -38,30 +38,123 @@
 
     <div class="people-grid">
       <article class="person-card artist" data-role="artist">
-        <img src="/assets/people/marilyn-aleman.jpg" alt="Portrait of Marilyn Aleman" />
         <h3>Marilyn Aleman</h3>
         <p class="role">Artist</p>
       </article>
       <article class="person-card instructor" data-role="instructor">
-        <img src="/assets/people/ramona-daniels.jpg" alt="Portrait of Ramona Daniels" />
         <h3>Ramona Daniels</h3>
         <p class="role">Instructor – Watercolor</p>
       </article>
       <article class="person-card board" data-role="board">
-        <img src="/assets/people/mark-hobson.jpg" alt="Portrait of Mark Hobson" />
         <h3>Mark Hobson</h3>
         <p class="role">Board Vice President</p>
       </article>
+<article class="person-card artist" data-role="artist">
+  <h3>Steve Creighton</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Lisa Ananich Freeland</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Lesley Wysong</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card board" data-role="board">
+  <h3>Peggy Hobson</h3>
+  <p class="role">Board Member</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Don Wilka</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Angela Walthour</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Avon Waters</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Shelley Wilder</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Sara McCubbin</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Dixie Ben-net</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Corinne McAuley</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Michael Hickey</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Cheryl Sullivan</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Marita Barber</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Tammy Roe</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Patrick Redmon</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Alovea Chadwell</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Jan Stieglitz</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Vivian Bennett</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Kat Cloward</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Lana Kirtley</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Bertie David</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Karen Gardner</h3>
+  <p class="role">Artist</p>
+</article>
+<article class="person-card artist" data-role="artist">
+  <h3>Ken Gardner</h3>
+  <p class="role">Artist</p>
+</article>
     </div>
   </main>
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -42,11 +42,11 @@
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy" class="active">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html" class="active">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/style.css
+++ b/style.css
@@ -16,6 +16,9 @@ body {
   color: var(--gray-800);
   background: var(--gray-100);
 }
+.home #content {
+  text-align: center;
+}
 .container {
   width: min(90%, 1200px);
   margin-inline: auto;
@@ -106,6 +109,9 @@ body {
   gap: 2rem;
   margin: 3rem 0;
 }
+.highlight {
+  text-align: center;
+}
 .highlight h2 {
   margin-bottom: 0.5rem;
   color: var(--brand);
@@ -175,4 +181,86 @@ footer {
     padding: 1rem;
     display: block;
   }
+}
+/* Page links section */
+.page-links {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem;
+  margin: 2rem 0;
+  padding: 0;
+  text-align: center;
+}
+.page-links a {
+  text-decoration: none;
+  color: var(--brand);
+  font-weight: 600;
+}
+
+/* People page */
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+.filter-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--brand);
+  background: transparent;
+  color: var(--brand);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.filter-btn.active,
+.filter-btn:hover {
+  background: var(--brand);
+  color: #fff;
+}
+.people-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+.person-card {
+  text-align: center;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.person-card img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+/* Classes page */
+.class-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 2rem;
+}
+.class-card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+/* Membership table */
+.membership-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.membership-table th,
+.membership-table td {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--gray-100);
+  text-align: left;
 }

--- a/volunteer.html
+++ b/volunteer.html
@@ -9,18 +9,18 @@
 <body>
   <header>
     <nav class="navbar container">
-      <a class="logo" href="/">KAA</a>
+      <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="/about">About</a></li>
-        <li><a href="/people">People</a></li>
-        <li><a href="/events">Events</a></li>
-        <li><a href="/classes">Classes</a></li>
-        <li><a href="/artworks-gallery">Gallery</a></li>
-        <li><a href="/membership">Join</a></li>
-        <li><a href="/volunteer" class="active">Volunteer</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="people.html">People</a></li>
+        <li><a href="events.html">Events</a></li>
+        <li><a href="classes.html">Classes</a></li>
+        <li><a href="artworks_gallery.html">Gallery</a></li>
+        <li><a href="membership.html">Join</a></li>
+        <li><a href="volunteer.html" class="active">Volunteer</a></li>
         <li><a class="btn-donate" href="https://kokomoartassociation.networkforgood.com/projects/218762-donate-to-the-kokomo-art-association-llc" target="_blank" rel="noopener">Donate</a></li>
-        <li><a href="/contact-us">Contact</a></li>
+        <li><a href="contact_us.html">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -42,11 +42,11 @@
 
   <footer>
     <div class="footer-links container">
-      <a href="/about">About</a>
-      <a href="/people">People</a>
-      <a href="/events">Events</a>
-      <a href="/contact-us">Contact</a>
-      <a href="/privacy">Privacy</a>
+      <a href="about.html">About</a>
+      <a href="people.html">People</a>
+      <a href="events.html">Events</a>
+      <a href="contact_us.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>

--- a/watercolor_techniques.html
+++ b/watercolor_techniques.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>About | Kokomo Art Association</title>
+  <title>Watercolor Techniques | Kokomo Art Association</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -12,10 +12,10 @@
       <a class="logo" href="index.html">KAA</a>
       <button class="toggle" aria-label="Toggle navigation">☰</button>
       <ul class="nav-links">
-        <li><a href="about.html" class="active">About</a></li>
+        <li><a href="about.html">About</a></li>
         <li><a href="people.html">People</a></li>
         <li><a href="events.html">Events</a></li>
-        <li><a href="classes.html">Classes</a></li>
+        <li><a href="classes.html" class="active">Classes</a></li>
         <li><a href="artworks_gallery.html">Gallery</a></li>
         <li><a href="membership.html">Join</a></li>
         <li><a href="volunteer.html">Volunteer</a></li>
@@ -24,30 +24,10 @@
       </ul>
     </nav>
   </header>
-
   <main id="content" class="container">
-    <h1>About the Kokomo Art Association</h1>
-    <p class="lead">Since 1926, the Kokomo Art Association (KAA) has championed visual arts education, exhibition, and community engagement throughout north‑central Indiana.</p>
-
-    <h2>Our Mission</h2>
-    <p>To connect, educate, and inspire through the visual arts, ensuring art is accessible to <em>all</em> in our community.</p>
-
-    <h2>Centennial Timeline</h2>
-    <ul class="timeline">
-      <li><strong>1926:</strong> First informal gathering of local artists; KAA founded.</li>
-      <li><strong>1950s–1970s:</strong> Regular juried shows, school outreach, and traveling exhibits.</li>
-      <li><strong>2014:</strong> Artist Alley opens in downtown Kokomo.</li>
-      <li><strong>2025:</strong> 12th Annual Artist Alley project and centennial celebrations underway.</li>
-    </ul>
-
-    <h2>Impact by the Numbers (2024)</h2>
-    <ul>
-      <li>📈 4,200 gallery visitors</li>
-      <li>🎨 630 class enrollments</li>
-      <li>🖼️ 95 regional artists exhibited</li>
-    </ul>
+    <h1>Watercolor Techniques</h1>
+    <p class="lead">More information about this class will be available soon.</p>
   </main>
-
   <footer>
     <div class="footer-links container">
       <a href="about.html">About</a>
@@ -58,7 +38,6 @@
     </div>
     <p class="copyright">© 2025 Kokomo Art Association. All rights reserved.</p>
   </footer>
-
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove broken portrait links from the People page
- center all homepage content and highlights

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882bd3a523c8328b016eb2a6c086970